### PR TITLE
fix: login translations, ticker copy, and currency label

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,24 +123,24 @@ class _NinaVerdeAppState extends State<NinaVerdeApp> {
 
   // ----- Default messages (EN) -----
   static List<String> _defaultsEn() => const [
-        "Naturally, Welcome to Nicaragua Niña Verde!",
-        "Login to collect points.",
+        "Naturally, welcome to Nicaragua Niña Verde!",
+        "Log in to collect points.",
         "Get exclusive offers.",
         "Earn rewards.",
         "Enjoy free services.",
         "Tune into the best entertainment.",
         "Engage the community.",
         "Catch the _VYBZ!_",
-        "Come for the food, Stay for the _VYBZ!_",
+        "Come for the food, stay for the _VYBZ!_",
       ];
 
   static List<String> _defaultsEsFromEn(List<String> en) {
     String tr(String s) {
       return s
-          .replaceAll("Naturally, Welcome to Nicaragua Niña Verde!",
+          .replaceAll("Naturally, welcome to Nicaragua Niña Verde!",
               "Naturalmente, ¡Bienvenido a Nicaragua Niña Verde!")
           .replaceAll(
-              "Login to collect points.", "Inicia sesión para acumular puntos.")
+              "Log in to collect points.", "Inicia sesión para acumular puntos.")
           .replaceAll("Get exclusive offers.", "Obtén ofertas exclusivas.")
           .replaceAll("Earn rewards.", "Gana recompensas.")
           .replaceAll("Enjoy free services.", "Disfruta servicios gratis.")
@@ -148,8 +148,8 @@ class _NinaVerdeAppState extends State<NinaVerdeApp> {
               "Sintoniza el mejor entretenimiento.")
           .replaceAll("Engage the community.", "Participa en la comunidad.")
           .replaceAll("Catch the _VYBZ!_", "¡Atrapa el _VYBZ!_")
-          .replaceAll("Come for the food, Stay for the _VYBZ!_",
-              "Ven por la comida, quédate por el _VYBZ!");
+          .replaceAll("Come for the food, stay for the _VYBZ!_",
+              "Ven por la comida, quédate por el _VYBZ!_");
     }
 
     return en.map(tr).toList();
@@ -395,15 +395,15 @@ class NvAppBar extends StatelessWidget implements PreferredSizeWidget {
     const esMap = {
       'dark': 'Oscuro',
       'light': 'Claro',
-      'lang_tip_es': 'Cambiar a Inglés (mantener para ajustes)',
-      'lang_tip_en': 'Switch to Español (mantener para ajustes)',
+      'lang_tip_es': 'Cambiar a inglés (mantener para ajustes)',
+      'lang_tip_en': 'Cambiar a español (mantener para ajustes)',
       'cur_tip': 'Mantener para ajustes de moneda',
     };
     const enMap = {
       'dark': 'Dark',
       'light': 'Light',
       'lang_tip_es': 'Switch to English (long-press for settings)',
-      'lang_tip_en': 'Cambiar a Español (mantener para ajustes)',
+      'lang_tip_en': 'Switch to Spanish (long-press for settings)',
       'cur_tip': 'Long-press for currency settings',
     };
     return (es ? esMap : enMap)[key]!;
@@ -800,7 +800,7 @@ class CurrencySettingsPage extends StatelessWidget {
             value: 'NIO',
             groupValue: app.currencyCode.value,
             onChanged: (v) => app.currencyCode.value = v!,
-            title: const Text('NIO — Córdoba (Nicaragua)'),
+            title: const Text('NIO — Nicaraguan Córdoba'),
           ),
         ],
       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -118,44 +118,44 @@ class _LoginScreenState extends State<LoginScreen>
     final es = AppState.of(context).isSpanish.value;
 
     const esMap = {
-      'title': 'Nia Verde  Iniciar sesin',
+      'title': 'Iniciar sesión',
       'email': 'Correo',
-      'password': 'Contrasea',
-      'login': 'Acceder',
-      'forgot': 'Olvidaste tu contrasea?',
+      'password': 'Contraseña',
+      'login': 'Iniciar sesión',
+      'forgot': '¿Olvidaste tu contraseña?',
       'google': 'Google',
       'facebook': 'Facebook',
       'apple': 'Apple',
       'microsoft': 'Microsoft',
       'guest': 'Continuar como invitado',
-      'noAccount': 'No tienes cuenta? Regstrate!',
-      'contact': 'Contctenos',
-      'privacy': 'Poltica de Privacidad',
-      'deletion': 'Eliminacin de Datos',
+      'noAccount': '¿No tienes cuenta? Regístrate!',
+      'contact': 'Contáctenos',
+      'privacy': 'Política de Privacidad',
+      'deletion': 'Eliminación de Datos',
       'show': 'Mostrar',
       'hide': 'Ocultar',
       'enter_email': 'Ingresa tu correo',
-      'enter_password': 'Ingresa tu contrasea',
-      'reset_title': 'Restablecer contrasea',
+      'enter_password': 'Ingresa tu contraseña',
+      'reset_title': 'Restablecer contraseña',
       'send': 'Enviar',
       'cancel': 'Cancelar',
       'reset_sent': 'Correo de restablecimiento enviado.',
-      'err_invalid_email': 'Correo invlido.',
+      'err_invalid_email': 'Correo inválido.',
       'err_user_not_found': 'No existe un usuario con ese correo.',
-      'err_wrong_password': 'Contrasea incorrecta.',
+      'err_wrong_password': 'Contraseña incorrecta.',
       'err_network': 'Error de red. Intenta de nuevo.',
-      'err_generic': 'Error al iniciar sesin',
+      'err_generic': 'Error al iniciar sesión.',
       'fb_no_email':
-          'No recibimos tu email de Facebook. Por favor, otorga el permiso de email.',
-      'fb_cancelled': 'Inicio de sesin con Facebook cancelado.',
-      'play_video': 'Reproducir video de introduccin',
-      'or_rapid': 'Inicio rpido con',
-      'video_url_hint': 'Pega URL de YouTube (https://youtu.be/ o watch?v=)',
-      'logo_url_hint': 'Pega URL del logo (https:// .png/.jpg)',
+          'No recibimos tu correo electrónico de Facebook. Por favor, otorga el permiso de correo electrónico.',
+      'fb_cancelled': 'Inicio de sesión con Facebook cancelado.',
+      'play_video': 'Reproducir video de introducción',
+      'or_rapid': 'O inicia sesión con',
+      'video_url_hint': 'Pega la URL de YouTube (https://youtu.be/ o watch?v=)',
+      'logo_url_hint': 'Pega la URL del logo (https:// .png/.jpg)',
       // Popup dialog:
-      'popup_title': 'Configuracin del Popup',
+      'popup_title': 'Configuración del popup',
       'yt_label': 'URL de YouTube',
-      'logo_label': 'URL del Logo (opcional)',
+      'logo_label': 'URL del logo (opcional)',
       'save_btn': 'Guardar',
       'saving_btn': 'Guardando',
       'make_default_btn': 'Hacer predeterminado',
@@ -166,10 +166,10 @@ class _LoginScreenState extends State<LoginScreen>
     };
 
     const enMap = {
-      'title': 'Nia Verde  Sign In',
+      'title': 'Login',
       'email': 'Email',
       'password': 'Password',
-      'login': 'Login',
+      'login': 'Log in',
       'forgot': 'Forgot password?',
       'google': 'Google',
       'facebook': 'Facebook',
@@ -197,7 +197,7 @@ class _LoginScreenState extends State<LoginScreen>
           'We did not receive your Facebook email. Please ensure the email permission is granted.',
       'fb_cancelled': 'Facebook sign-in cancelled.',
       'play_video': 'Play intro video',
-      'or_rapid': 'Or Rapid Sign In With',
+      'or_rapid': 'Or sign in with',
       'video_url_hint': 'Paste YouTube URL (https://youtu.be/ or watch?v=)',
       'logo_url_hint': 'Paste logo image URL (https:// .png/.jpg)',
       // Popup dialog:
@@ -915,6 +915,7 @@ class _LoginScreenState extends State<LoginScreen>
                                 final idx = s.lastIndexOf(' ');
                                 if (idx <= 0) return Text(s);
                                 final left = s.substring(0, idx + 1);
+                                final right = s.substring(idx + 1);
                                 return RichText(
                                   text: TextSpan(
                                     style: DefaultTextStyle.of(ctx)
@@ -922,10 +923,10 @@ class _LoginScreenState extends State<LoginScreen>
                                         .copyWith(fontWeight: FontWeight.w700),
                                     children: [
                                       TextSpan(text: left),
-                                      const TextSpan(
-                                        text: 'Regstrate!',
+                                      TextSpan(
+                                        text: right,
                                         style:
-                                            TextStyle(color: kNvAccentOrange),
+                                            const TextStyle(color: kNvAccentOrange),
                                       ),
                                     ],
                                   ),


### PR DESCRIPTION
### Motivation
- Correct multiple misspellings, missing accents and awkward phrasing on the login screen so Spanish and English copy read naturally and consistently.
- Ensure the Register call-to-action is not hardcoded to the misspelled `Regstrate` and instead highlights the actual localized CTA text from the resource map.
- Make the ticker default messages and their Spanish replacements grammatically and punctuationally consistent.
- Clarify language tooltip wording and the currency label shown for `NIO` so the UI copy is accurate and user-friendly.

### Description
- Updated the ES/EN tiny translation maps in `lib/screens/login_screen.dart` to fix spelling, accents and wording for keys such as `title`, `login`, `noAccount`, `forgot`, error messages, and popup labels.
- Replaced the hardcoded highlighted text fragment with a dynamic split so the last word from the `noAccount` string is highlighted (fixing the `Regstrate` issue) in `lib/screens/login_screen.dart`.
- Revised default ticker copy in `lib/main.dart` (capitalization, punctuation and phrasing) and adjusted the Spanish auto-replacements to match the updated English strings.
- Improved AppBar tooltip strings for language switching and updated the currency settings label to `NIO — Nicaraguan Córdoba` in `lib/main.dart`.

### Testing
- No automated tests were run against these changes.
- Changes were compiled into a commit locally; no CI/unit test results are available from this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f27c2ead88329bccd264f8a7b496f)