### PR TITLE
fix: login video autoplay and embed parsing

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -524,15 +524,13 @@ class _LoginScreenState extends State<LoginScreen>
 
     final yt = YoutubePlayerController.fromVideoId(
       videoId: id,
+      autoPlay: true,
       params: const YoutubePlayerParams(
         playsInline: true,
         showFullscreenButton: true,
         strictRelatedVideos: true,
       ),
     );
-
-    // Start playback after first build
-    WidgetsBinding.instance.addPostFrameCallback((_) => yt.playVideo());
 
     final ctrl = AnimationController(
       vsync: this,
@@ -626,10 +624,11 @@ class _LoginScreenState extends State<LoginScreen>
     if (u.host.contains('youtu.be') && u.pathSegments.isNotEmpty) {
       return u.pathSegments.first;
     }
-    // youtube.com/watch?v=<id> (and shorts/<id>)
-    if (u.host.contains('youtube.com')) {
-      final shorts = u.pathSegments;
-      if (shorts.length >= 2 && shorts[0] == 'shorts') return shorts[1];
+    // youtube.com/watch?v=<id> (and shorts/<id>, embed/<id>)
+    if (u.host.contains('youtube.com') || u.host.contains('youtube-nocookie')) {
+      final segments = u.pathSegments;
+      if (segments.length >= 2 && segments[0] == 'shorts') return segments[1];
+      if (segments.length >= 2 && segments[0] == 'embed') return segments[1];
       return u.queryParameters['v'];
     }
     // raw id


### PR DESCRIPTION
### Motivation
- Ensure the intro video actually starts when the user taps the logo by enabling autoplay instead of relying on a post-frame callback.
- Accept more YouTube URL formats (embed and youtube-nocookie) so supplied links and embedded iframe URLs resolve to the correct video id.
- Improve reliability of the login overlay video behavior so the user can open/close the player repeatedly without playback failures.

### Description
- Enabled autoplay by passing `autoPlay: true` to `YoutubePlayerController.fromVideoId` and removed the manual `WidgetsBinding.instance.addPostFrameCallback` playback kick.
- Extended `_extractYoutubeId` to parse `embed/<id>` path segments and `youtube-nocookie` hosts in addition to `youtu.be` and `watch?v=` formats.
- All changes are contained in `lib/screens/login_screen.dart` (small insertion/removal around the YouTube controller creation and URL parsing).

### Testing
- No automated tests were executed for this change.
- An attempt to fetch packages with `flutter pub get` failed in the environment because the `flutter` command was not available. 
- Manual runtime verification was not performed by the automated pipeline in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f23a55c248329aed40641b9cb7caf)