### PR TITLE
fix: provide cartprovider at app root

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:provider/provider.dart';
 
 // WebView (universal, with per-platform creation params)
 import 'package:webview_flutter/webview_flutter.dart';
@@ -19,6 +20,7 @@ import 'screens/document_webview.dart'
     show DocumentWebView; // standalone WebView screen
 import 'screens/contact_nina_verde_page.dart'
     show ContactNinaVerdePage; // <-- NEW: AI Contact page
+import 'providers/cart_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,7 +32,12 @@ Future<void> main() async {
   FirebaseFirestore.instance.settings =
       const Settings(persistenceEnabled: true);
 
-  runApp(const NinaVerdeApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => CartProvider(),
+      child: const NinaVerdeApp(),
+    ),
+  );
 }
 
 /// ---------- Global app state ----------


### PR DESCRIPTION
### Motivation
- Fix the runtime "Could not find the correct Provider<CartProvider> above this HomeScreen Widget" error by making the `CartProvider` available to the whole app.
- Ensure widgets using `Provider.of`, `context.read`, or `Consumer<CartProvider>` can access the cart state from any route.

### Description
- Added `package:provider/provider.dart` import and `providers/cart_provider.dart` import to `lib/main.dart`.
- Wrapped `runApp(const NinaVerdeApp())` with `ChangeNotifierProvider(create: (_) => CartProvider(), child: const NinaVerdeApp())` so the `CartProvider` is registered at the app entry point.
- Modified only `lib/main.dart` to register the provider at the application root.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1e5f22148329a7637c166d7540ef)