### PR TITLE
fix: brand color constants usage in theme and document view

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,10 +77,6 @@ class AppState extends InheritedWidget {
   /// Convenience: open the video pop-up
   final void Function(BuildContext ctx) openPip;
 
-  /// Brand colors shared across screens and themes.
-  static const Color nvGreenDark = Color(0xFF022F18);
-  static const Color nvDarkSurface = Color(0xFF0B2C1E);
-
   const AppState({
     super.key,
     required this.themeMode,
@@ -334,7 +330,7 @@ class _NinaVerdeAppState extends State<NinaVerdeApp> {
                 theme: ThemeData(
                   useMaterial3: true,
                   colorScheme: ColorScheme.fromSeed(
-                    seedColor: AppState.nvGreenDark,
+                    seedColor: kNvGreenDark,
                     surface: const Color(0xFFE9F6E9),
                   ),
                   appBarTheme: const AppBarTheme(centerTitle: true),
@@ -343,13 +339,13 @@ class _NinaVerdeAppState extends State<NinaVerdeApp> {
                   useMaterial3: true,
                   brightness: Brightness.dark,
                   colorScheme: ColorScheme.fromSeed(
-                    seedColor: AppState.nvGreenDark,
+                    seedColor: kNvGreenDark,
                     brightness: Brightness.dark,
-                    surface: AppState.nvDarkSurface,
+                    surface: kNvDarkSurface,
                   ),
-                  scaffoldBackgroundColor: AppState.nvGreenDark,
+                  scaffoldBackgroundColor: kNvGreenDark,
                   appBarTheme: const AppBarTheme(
-                    backgroundColor: AppState.nvGreenDark,
+                    backgroundColor: kNvGreenDark,
                     centerTitle: true,
                   ),
                 ),

--- a/lib/screens/document_webview.dart
+++ b/lib/screens/document_webview.dart
@@ -124,8 +124,8 @@ class _DocumentWebViewState extends State<DocumentWebView> {
             gradient: LinearGradient(
               colors: isDark
                   ? [
-                      AppState.nvGreenDark,
-                      AppState.nvDarkSurface,
+                      kNvGreenDark,
+                      kNvDarkSurface,
                       Colors.black,
                     ]
                   : [


### PR DESCRIPTION
### Motivation
- Remove duplicated static brand color fields from `AppState` to avoid mixing instance/static color definitions and reduce confusion.
- Consolidate on the existing shared top-level constants `kNvGreenDark` and `kNvDarkSurface` for consistent branding across the app.
- Ensure dark-theme `ColorScheme` and UI gradients use the same canonical color values.

### Description
- Deleted `AppState` static color definitions and switched theme usage to `kNvGreenDark` and `kNvDarkSurface` in `lib/main.dart` for both `theme` and `darkTheme` configurations.
- Replaced references in the dark gradient of `DocumentWebView` with `kNvGreenDark` and `kNvDarkSurface` in `lib/screens/document_webview.dart`.
- Updated `scaffoldBackgroundColor` and `AppBar` background references to use the shared constants for consistent dark-mode styling.

### Testing
- No automated tests were executed for this change.
- Local static analysis and quick file edits were applied and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a5d289e08329a988ba3d6c403367)