### PR TITLE
fix: add splash watchdog to prevent hanging on boot

### DIFF
--- a/lib/screens/splash_to_login.dart
+++ b/lib/screens/splash_to_login.dart
@@ -75,6 +75,7 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
 
   // Watchdog so "video" phase can’t hang
   Timer? _videoWatchdog;
+  Timer? _sequenceWatchdog;
 
   @override
   void initState() {
@@ -111,6 +112,12 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
     _finalReveal =
         AnimationController(vsync: this, duration: finalRevealDuration);
 
+    _sequenceWatchdog = Timer(const Duration(seconds: 15), () {
+      if (mounted && !_navigated) {
+        _goToLogin();
+      }
+    });
+
     _runSequence();
   }
 
@@ -132,49 +139,60 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
   }
 
   Future<void> _runSequence() async {
-    // Intro pop + light whoosh during bloom (unchanged)
-    setState(() => _phase = _Phase.introLogo);
-    unawaited(() async {
-      await Future.delayed(const Duration(milliseconds: 260));
-      await _playWhoosh(0.95);
-    }());
-    await _introLogoCtrl.forward();
-    _introLogoCtrl.reset();
+    try {
+      // Intro pop + light whoosh during bloom (unchanged)
+      if (!mounted) return;
+      setState(() => _phase = _Phase.introLogo);
+      unawaited(() async {
+        await Future.delayed(const Duration(milliseconds: 260));
+        await _playWhoosh(0.95);
+      }());
+      await _introLogoCtrl.forward();
+      _introLogoCtrl.reset();
 
-    // FLASH 0 (NV) — intro → POWERED
-    setState(() => _phase = _Phase.flash0);
-    await _flash0.forward();
-    _flash0.reset();
+      // FLASH 0 (NV) — intro → POWERED
+      if (!mounted) return;
+      setState(() => _phase = _Phase.flash0);
+      await _flash0.forward();
+      _flash0.reset();
 
-    // POWERED (holds)
-    setState(() => _phase = _Phase.powered);
-    unawaited(_playWhoosh(1.0));
-    await Future.delayed(poweredDuration);
+      // POWERED (holds)
+      if (!mounted) return;
+      setState(() => _phase = _Phase.powered);
+      unawaited(_playWhoosh(1.0));
+      await Future.delayed(poweredDuration);
 
-    // FLASH 1 (Biz) — POWERED → BY
-    setState(() => _phase = _Phase.flash1);
-    await _flash1.forward();
-    _flash1.reset();
+      // FLASH 1 (Biz) — POWERED → BY
+      if (!mounted) return;
+      setState(() => _phase = _Phase.flash1);
+      await _flash1.forward();
+      _flash1.reset();
 
-    // BY (holds)
-    setState(() => _phase = _Phase.by);
-    unawaited(_playWhoosh(1.0));
-    await Future.delayed(byDuration);
+      // BY (holds)
+      if (!mounted) return;
+      setState(() => _phase = _Phase.by);
+      unawaited(_playWhoosh(1.0));
+      await Future.delayed(byDuration);
 
-    // FLASH 2 (Biz) — BY → Video
-    setState(() => _phase = _Phase.flash2);
-    await _flash2.forward();
-    _flash2.reset();
+      // FLASH 2 (Biz) — BY → Video
+      if (!mounted) return;
+      setState(() => _phase = _Phase.flash2);
+      await _flash2.forward();
+      _flash2.reset();
 
-    // Video
-    setState(() => _phase = _Phase.video);
-    unawaited(_playWhoosh(1.0));
-    if (_videoReady) {
-      _enterVideoPhase();
-    } else {
-      // Fallback if init lags
-      await Future.delayed(const Duration(seconds: 2));
-      _doFinalReveal();
+      // Video
+      if (!mounted) return;
+      setState(() => _phase = _Phase.video);
+      unawaited(_playWhoosh(1.0));
+      if (_videoReady) {
+        _enterVideoPhase();
+      } else {
+        // Fallback if init lags
+        await Future.delayed(const Duration(seconds: 2));
+        _doFinalReveal();
+      }
+    } catch (_) {
+      _goToLogin();
     }
   }
 
@@ -228,6 +246,8 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
     // Stop watchdog once we move on
     _videoWatchdog?.cancel();
     _videoWatchdog = null;
+    _sequenceWatchdog?.cancel();
+    _sequenceWatchdog = null;
 
     unawaited(_playWhoosh(1.0));
     setState(() => _phase = _Phase.finalReveal);
@@ -239,6 +259,8 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
   void _goToLogin() {
     if (_navigated) return;
     _navigated = true;
+    _sequenceWatchdog?.cancel();
+    _sequenceWatchdog = null;
     if (!mounted) return;
     Navigator.of(context).pushReplacement(
       PageRouteBuilder(
@@ -253,6 +275,7 @@ class _SplashToLoginScreenState extends State<SplashToLoginScreen>
   @override
   void dispose() {
     _videoWatchdog?.cancel();
+    _sequenceWatchdog?.cancel();
     _introLogoCtrl.dispose();
     _flash0.dispose();
     _flash1.dispose();
@@ -938,4 +961,3 @@ class _SpeckPainter extends CustomPainter {
   bool shouldRepaint(covariant _SpeckPainter old) =>
       old.progress != progress || old.center != center;
 }
-


### PR DESCRIPTION
### Motivation
- The splash-to-login sequence could stall during the intro/video phases and leave the app frozen on the first splash frame.
- Ensure the app always transitions to the `LoginScreen` even if animations or video initialization hang.

### Description
- Added a `_sequenceWatchdog` `Timer` in `lib/screens/splash_to_login.dart` that calls `_goToLogin()` after 15 seconds if navigation hasn't occurred.
- Hardened `_runSequence()` with `mounted` checks at key steps and wrapped the sequence in a `try/catch` that falls back to `_goToLogin()` on error.
- Cancelled the new `_sequenceWatchdog` when performing `_doFinalReveal()`, in `_goToLogin()`, and in `dispose()` to avoid leaks. 
- Retained the existing `_videoWatchdog` behavior and existing timing fallbacks for video initialization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627b50862c83299e444c194e757548)